### PR TITLE
1 bugfix, and two optional bugfixes

### DIFF
--- a/telethon_secret_chat/secret_chat_manager.py
+++ b/telethon_secret_chat/secret_chat_manager.py
@@ -87,8 +87,12 @@ class SecretChatManager(SecretChatMethods):
                 (event_type, callback) = events
                 if event_type == SECRET_TYPES.decrypt:
                     if not decrypted_event:
-                        decrypted_event = await self.handle_encrypted_update(event)
-                        if "DecryptedMessage" not in type(decrypted_event).__name__:
+                        decrypted_event = await self.handle_encrypted_update(event
+                        decrypted_event_type = type(decrypted_event).__name__
+                        if("DecryptedMessage" not in decrypted_event_type  or 
+                           "DecryptedMessageService" in decrypted_event_type):
+                            # exclude decrypted message service in order to restrict
+                            # what the callback receives)
                             return
 
                         self.patch_event(event, decrypted_event)

--- a/telethon_secret_chat/secret_chat_manager.py
+++ b/telethon_secret_chat/secret_chat_manager.py
@@ -87,7 +87,7 @@ class SecretChatManager(SecretChatMethods):
                 (event_type, callback) = events
                 if event_type == SECRET_TYPES.decrypt:
                     if not decrypted_event:
-                        decrypted_event = await self.handle_encrypted_update(event
+                        decrypted_event = await self.handle_encrypted_update(event)
                         decrypted_event_type = type(decrypted_event).__name__
                         if("DecryptedMessage" not in decrypted_event_type  or 
                            "DecryptedMessageService" in decrypted_event_type):

--- a/telethon_secret_chat/secret_methods.py
+++ b/telethon_secret_chat/secret_methods.py
@@ -257,7 +257,7 @@ class SecretChatMethods:
         del self._temp_rekeyed_secret_chats[action.exchange_id]
         peer.rekeying = [0]
         peer.auth_key = auth_key
-        peer.ttl = 100
+        peer.ttr = 100
         peer.updated = time()
 
     async def complete_rekey(self, peer, action: DecryptedMessageActionCommitKey):

--- a/telethon_secret_chat/secret_methods.py
+++ b/telethon_secret_chat/secret_methods.py
@@ -560,6 +560,10 @@ class SecretChatMethods:
         peer = self.get_secret_chat(peer)
         if peer.layer == 8:
             return
+        # override a layer downgrade below 101 so that markdown strikethrough doesn't error out
+        if peer.layer < DEFAULT_LAYER:
+            self._log.debug(f'notify_layer: overriding layer {peer.layer} to {DEFAULT_LAYER}')
+            peer.layer = DEFAULT_LAYER
         message = DecryptedMessageService8(action=DecryptedMessageActionNotifyLayer(
             layer=min(DEFAULT_LAYER, peer.layer)), random_bytes=os.urandom(15 + 4 * random.randint(0, 2)))
         data = await self.encrypt_secret_message(peer.id, message)


### PR DESCRIPTION
Hi,

I fixed an issue where the rekeying goes into an infinite loop because the variable was named incorrectly (peer.ttl vs peer.ttr).

Also two other changes were made to enable strikethrough markdown to work, as well as to reduce unexpected event structure in the eventhandler, since it was still receiving decryptedmessageservice events rather than just decryptedmessage events.

Hope it's helpful.

lpf